### PR TITLE
fix: handle WhatsApp blob out of memory errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/whatsapp-web.js",
-  "version": "1.30.28",
+  "version": "1.30.29",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/Client.js
+++ b/src/Client.js
@@ -120,8 +120,12 @@ class Client extends EventEmitter {
 
         // bridge browser log
         this.pupPage.on('console', msg => {
-            console.log('PUPPETEER PAGE LOG:', msg.text());
-            if (msg.text().includes('ERR_OUT_OF_MEMORY')) {
+            const text = msg.text();
+            console.log('PUPPETEER PAGE LOG:', text);
+            if (
+                text.includes('ERR_OUT_OF_MEMORY') ||
+                text.includes('ERR_BLOB_OUT_OF_MEMORY')
+            ) {
                 this.emit(Events.CHROME_OOM);
             }
         });

--- a/tests/client-oom.js
+++ b/tests/client-oom.js
@@ -1,0 +1,83 @@
+const chai = require('chai');
+const sinon = require('sinon');
+
+const Client = require('../src/Client');
+const { Events } = require('../src/util/Constants');
+
+const expect = chai.expect;
+
+async function createPageConsoleListener() {
+    const client = new Client({ authTimeoutMs: 100 });
+    const stopAfterListenerRegistration = new Error('stop after page console listener registration');
+    let evaluateCallCount = 0;
+    let pageConsoleListener;
+
+    client.setDeviceName = async () => undefined;
+    client.getWWebVersion = async () => 'test-version';
+    client.pupPage = {
+        evaluate: async () => {
+            evaluateCallCount += 1;
+            if (evaluateCallCount === 1) {
+                return true;
+            }
+            if (evaluateCallCount === 2) {
+                return undefined;
+            }
+            throw stopAfterListenerRegistration;
+        },
+        on: (eventName, listener) => {
+            if (eventName === 'console') {
+                pageConsoleListener = listener;
+            }
+        },
+    };
+
+    try {
+        await client.inject();
+    } catch (error) {
+        if (error !== stopAfterListenerRegistration) {
+            throw error;
+        }
+    }
+
+    expect(pageConsoleListener).to.be.a('function');
+    return { client, pageConsoleListener };
+}
+
+describe('Client chrome OOM detection', function () {
+    it('emits chrome_oom for blob memory exhaustion', async function () {
+        const { client, pageConsoleListener } = await createPageConsoleListener();
+        const callback = sinon.spy();
+        client.on(Events.CHROME_OOM, callback);
+
+        pageConsoleListener({
+            text: () => 'Failed to load resource: net::ERR_BLOB_OUT_OF_MEMORY',
+        });
+
+        expect(callback.calledOnce).to.equal(true);
+    });
+
+    it('keeps emitting chrome_oom for general memory exhaustion', async function () {
+        const { client, pageConsoleListener } = await createPageConsoleListener();
+        const callback = sinon.spy();
+        client.on(Events.CHROME_OOM, callback);
+
+        pageConsoleListener({
+            text: () => 'Failed to load resource: net::ERR_OUT_OF_MEMORY',
+        });
+
+        expect(callback.calledOnce).to.equal(true);
+    });
+
+    it('does not emit chrome_oom for an unrelated page log', async function () {
+        const { client, pageConsoleListener } = await createPageConsoleListener();
+        const callback = sinon.spy();
+        client.on(Events.CHROME_OOM, callback);
+
+        pageConsoleListener({
+            text: () => 'Failed to load resource: net::ERR_NAME_NOT_RESOLVED',
+        });
+
+        expect(callback.called).to.equal(false);
+    });
+});


### PR DESCRIPTION
## Summary
- emit `chrome_oom` for Chromium `ERR_BLOB_OUT_OF_MEMORY` console failures
- preserve existing `ERR_OUT_OF_MEMORY` handling
- bump `@juzi/whatsapp-web.js` to `1.30.29`

## Test plan
- [x] `npx mocha tests/client-oom.js --timeout 5000` (3 passing)
- [x] `npx eslint src/Client.js tests/client-oom.js`
- [x] `npm pack` includes the updated `src/Client.js`