### PR TITLE
fix: getChat 对 LID 寻址会话做 lid 回退,修复联系人无法同步

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -752,7 +752,22 @@ exports.LoadUtils = () => {
                 chat = null;
             }
         } else {
-            chat = (window.require('WAWebCollections')).Chat.get(chatWid) || (await (window.require('WAWebFindChatAction')).findOrCreateLatestChat(chatWid))?.chat;
+            chat = (window.require('WAWebCollections')).Chat.get(chatWid);
+            if (!chat) {
+                try {
+                    chat = (await (window.require('WAWebFindChatAction')).findOrCreateLatestChat(chatWid))?.chat;
+                } catch (err) {
+                    // LID 寻址账号下会话按 @lid wid 存储,用 PN(@c.us)wid 调
+                    // findOrCreateLatestChat 会抛 WhatsApp 内部断言异常;
+                    // 映射到 lid wid 后重试,映射不到才原样抛出
+                    const { lid } = await window.WWebJS.enforceLidAndPnRetrieval(chatId);
+                    if (!lid) {
+                        throw err;
+                    }
+                    chat = (window.require('WAWebCollections')).Chat.get(lid)
+                        || (await (window.require('WAWebFindChatAction')).findOrCreateLatestChat(lid))?.chat;
+                }
+            }
         }
 
         return getAsModel && chat


### PR DESCRIPTION
## 问题

test 环境 bot 6a58af469b8099457f462ee3 登录后**联系人无法同步**。日志链路:

1. puppet `onWhatsAppReady`:登录成功、`getContacts()` 成功返回 47 个联系人
2. 逐联系人拉历史消息时 `contact.getChat()` → `Client.getChatById` → 页面内 `window.WWebJS.getChat()` 抛 WhatsApp 内部混淆异常 `r`
3. `onWhatsAppReady` 作为事件监听器运行,异常变成 unhandledRejection → **`ready` 事件从未发出** → xiaoju-bot 的 readyListener/syncContact 不执行 → 控制台看不到任何联系人

## 根因

LID 寻址账号下,会话在 `WAWebCollections.Chat` 中按 `@lid` wid 存储。`WWebJS.getChat` 的非 channel 路径:

```js
chat = Chat.get(chatWid) || (await findOrCreateLatestChat(chatWid))?.chat;
```

用 PN(`@c.us`)wid 调 `findOrCreateLatestChat` 时,WhatsApp 内部断言直接 throw(混淆后表现为 `r`)。与 #30 修复的 `sendMessage` 反查 miss 同属 LID 兼容问题家族。

## 修复

复用已有的 `WWebJS.enforceLidAndPnRetrieval`(PN→lid 映射,带 `queryWidExists` 兜底):PN 查找抛错时用 lid wid 重试 `Chat.get` / `findOrCreateLatestChat`,映射不到才原样抛出。命中 PN 的既有路径行为完全不变。

## 验证

- `node --check` 通过;注入代码需真机验证:用复现 bot(6a58af46...,test 环境)装本分支重登,预期 `onReady() all contacts and rooms are ready...` 日志出现、联系人正常同步
- 配套的 puppet 防御加固(单会话失败不打断 ready 链)在 wechaty-puppet-whatsapp 仓库另行提交

🤖 Generated with [Claude Code](https://claude.com/claude-code)
