### PR TITLE
fix: fixMessageLid 类型安全重写,修复发送返回路径 msg.from.endsWith 报错

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1333,95 +1333,58 @@ class Client extends EventEmitter {
     }
 
     async fixMessageLid(msg) {
-        if (msg.id.participant && msg.id.participant.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.id.participant);
-            if (contactId) {
-                msg.id.participant = contactId;
+        // 字段可能是字符串,也可能是 serialize() 产出的 wid 对象
+        // (如 sendMessage 返回的模型),统一取字符串形式
+        const idOf = (value) => {
+            if (typeof value === 'string') return value;
+            return value?._serialized ?? value?.id?._serialized ?? null;
+        };
+        // 归一为字符串并把 @lid 换回原 contact id;
+        // 上层(puppet payload parser)按字符串消费这些字段
+        const fixIdField = async (obj, key) => {
+            if (!obj) return;
+            const id = idOf(obj[key]);
+            if (!id) return;
+            if (id.endsWith('@lid')) {
+                const contactId = await this.getOriginalContactIdByLid(id);
+                obj[key] = contactId || id;
+            } else if (typeof obj[key] !== 'string') {
+                obj[key] = id;
             }
-        }
+        };
 
-        if (msg.id.remote && msg.id.remote.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.id.remote);
-            if (contactId) {
-                msg.id.remote = contactId;
-            }
-        }
+        await fixIdField(msg.id, 'participant');
+        await fixIdField(msg.id, 'remote');
+        await fixIdField(msg.reactionParentKey, 'participant');
+        await fixIdField(msg.parentMsgKey, 'participant');
+        await fixIdField(msg.msgKey, 'participant');
+        await fixIdField(msg, 'from');
+        await fixIdField(msg, 'to');
+        await fixIdField(msg, 'author');
+        await fixIdField(msg, 'senderUserJid');
 
-        if (msg.reactionParentKey?.participant && msg.reactionParentKey.participant.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.reactionParentKey.participant);
-            if (contactId) {
-                msg.reactionParentKey.participant = contactId;
-            }
-        }
-
-        if (msg.parentMsgKey?.participant && msg.parentMsgKey.participant.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.parentMsgKey.participant);
-            if (contactId) {
-                msg.parentMsgKey.participant = contactId;
-            }
-        }
-
-        if (msg.msgKey?.participant && msg.msgKey.participant.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.msgKey.participant);
-            if (contactId) {
-                msg.msgKey.participant = contactId;
-            }
-        }
-
-        if (msg.from && msg.from.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.from);
-            if (contactId) {
-                msg.from = contactId;
-            }
-        }
-
-
-        if (msg.to && msg.to.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.to);
-            if (contactId) {
-                msg.to = contactId;
-            }
-        }
-
-        if (msg.author && msg.author.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.author);
-            if (contactId) {
-                msg.author = contactId;
-            }
-        }
-
-        if (msg.senderUserJid && msg.senderUserJid.endsWith('@lid')) {
-            const contactId = await this.getOriginalContactIdByLid(msg.senderUserJid);
-            if (contactId) {
-                msg.senderUserJid = contactId;
-            }
-        }
-        
         if (msg.recipients?.length) {
             await Promise.all(
-                msg.recipients.map(async (item, index) => {
-                    if (item.endsWith('@lid')) {
-                        const contactId = await this.getOriginalContactIdByLid(item);
-                        if (contactId) {
-                            msg.recipients[index] = contactId;
-                        }
-                    }
-                })
+                msg.recipients.map((_, index) => fixIdField(msg.recipients, index))
             );
         }
 
         if (msg.mentionedJidList?.length) {
             await Promise.all(
                 msg.mentionedJidList.map(async (item, index) => {
-                    const jid = typeof item === 'object' ? item.id._serialized : item;
-                    const contact = await this.getContactById(item);
-                    const contactId = contact?.id._serialized;
+                    const jid = idOf(item);
+                    if (!jid) return;
+                    const contact = await this.getContactById(jid).catch(() => null);
+                    const contactId = contact?.id?._serialized;
                     if (jid.endsWith('@lid') && contactId) {
                         msg.mentionedJidList[index] = contactId;
                     }
-                    msg.body = msg.body.replaceAll(`@${item.split('@')[0]}`, `@${contact.name || contact.pushname}`);
-                    if (contactId) {
-                        msg.body = msg.body.replaceAll(`@${contactId.split('@')[0]}`, `@${contact.name || contact.pushname}`);
+                    const displayName = contact?.name || contact?.pushname;
+                    if (displayName && typeof msg.body === 'string') {
+                        msg.body = msg.body.replaceAll(`@${jid.split('@')[0]}`, `@${displayName}`);
+                        if (contactId) {
+                            msg.body = msg.body.replaceAll(`@${contactId.split('@')[0]}`, `@${displayName}`);
+                        }
                     }
                 })
             );


### PR DESCRIPTION
## 问题(#30 引入的回归)

test bot 6a58c4e6aaa774b3ed320d01 发文本消息,消息实际送达但控制台报"系统错误,请重启后稍后重试",且同一条消息保存两条(报错一条 + 手机回显一条)。日志:

```
19:50:36 ERR MessageSender sendMessage() ... sendMsgError: msg.from.endsWith is not a function
```

#30 给 `sendMessage` 返回值加了 `fixMessageLid` 清洗,但该函数假设 `from/to/id.remote` 等字段是**字符串**(入站事件历来如此);`sendMessage` 返回的模型经 `serialize()` 后这些字段可能是 **wid 对象**(`{server, user, _serialized}`),`.endsWith` 直接抛 TypeError → 发送再次走入报错分支,#30 想修的双消息问题换了个报错继续存在。

## 修复

`fixMessageLid` 整体重写为类型安全版本:

- 新增 `idOf`/`fixIdField` helper:所有 id 语义字段先归一为字符串(取 `_serialized`),`@lid` 转回原 contact id,写回一律字符串——与 puppet payload parser 的消费方式对齐(`messagePayload.author || messagePayload.from` 直接当字符串 id 用)
- 入站(纯字符串)路径行为完全不变
- 顺手加固 `mentionedJidList` 段的同类地雷:`item` 为对象时 `item.split('@')` 会炸、`getContactById` 失败时 `contact.name` 会炸,均已防御

## 验证

- `node --check` 通过
- 方法级独立用例(对象/字符串混合输入)9 项断言全过,覆盖线上实际炸点(`from` 为 wid 对象):对象→转换为字符串、字符串保持、lid 无映射时保底返回原字符串、getContactById 抛错不中断
- 真机验证建议:test bot 6a58c4e6 装本分支后从控制台发文本,预期不再报"系统错误"、message-data 单条、messageId 为 `3EB0...` 真实 id

🤖 Generated with [Claude Code](https://claude.com/claude-code)