### PR TITLE
fix: 修复 LID 灰度页面下群聊查找/序列化全链路崩溃

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1178,7 +1178,9 @@ class Client extends EventEmitter {
             const { createWid } = window.require('WAWebWidFactory');
             const channelWid = createWid(channelId);
             const chatWid = createWid(chatId);
-            const chat = window.require('WAWebCollections').Chat.get(chatWid) || (await (window.require('WAWebCollections')).Chat.find(chatWid));
+            // 新版页面 Chat 集合的 findImpl 已被移除,裸调 Chat.find 会抛 TypeError,
+            // 统一改用带降级链的 WWebJS.getChat(get → 内存扫描 → findOrCreateLatestChat)
+            const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
 
             if (!chatWid.isUser()) {
                 return false;
@@ -1422,7 +1424,7 @@ class Client extends EventEmitter {
     async getPinnedMessages(chatId) {
         const pinnedMsgs = await this.pupPage.evaluate(async (chatId) => {
             const chatWid = window.require('WAWebWidFactory').createWid(chatId);
-            const chat = (window.require('WAWebCollections')).Chat.get(chatWid) ?? await (window.require('WAWebCollections')).Chat.find(chatWid);
+            const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
             if (!chat) return [];
             
             const msgs = await (window.require('WAWebPinInChatSchema')).getTable().equals(['chatId'], chatWid.toString());
@@ -1683,7 +1685,7 @@ class Client extends EventEmitter {
      */
     async _muteUnmuteChat (chatId, action, unmuteDateTs) {
         return this.pupPage.evaluate(async (chatId, action, unmuteDateTs) => {
-            const chat = (window.require('WAWebCollections')).Chat.get(chatId) ?? await (window.require('WAWebCollections')).Chat.find(chatId);
+            const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
             action === 'MUTE'
                 ? await chat.mute.mute({ expiration: unmuteDateTs, sendDevice: true })
                 : await chat.mute.unmute({ sendDevice: true });
@@ -1890,7 +1892,6 @@ class Client extends EventEmitter {
             }
 
             parentGroupId && (parentGroupWid = window.require('WAWebWidFactory').createWid(parentGroupId));
-            participantWids.map(item => item.lid = item);
 
             try {
                 createGroupResult = await (window.require('WAWebGroupCreateJob')).createGroup(
@@ -1907,7 +1908,7 @@ class Client extends EventEmitter {
                     participantWids
                 );
             } catch (err) {
-                return 'CreateGroupError: An unknown error occupied while creating a group';
+                return 'CreateGroupError: ' + ((err && err.message) || err);
             }
 
             for (const participant of createGroupResult.participants) {
@@ -1919,7 +1920,7 @@ class Client extends EventEmitter {
                 if (autoSendInviteV4 && statusCode === 403) {
                     (window.require('WAWebCollections')).Contact.gadd(participant.wid, { silent: true });
                     const addParticipantResult = await (window.require('WAWebChatSendMessages')).sendGroupInviteMessage(
-                        (window.require('WAWebCollections')).Chat.get(participant.wid) || await (window.require('WAWebCollections')).Chat.find(participant.wid),
+                        await window.WWebJS.getChat(participantId, { getAsModel: false }),
                         createGroupResult.wid._serialized,
                         createGroupResult.subject,
                         participant.invite_code,
@@ -2532,8 +2533,7 @@ class Client extends EventEmitter {
      */
     async syncHistory(chatId) {
         return await this.pupPage.evaluate(async (chatId) => {
-            const chatWid = window.require('WAWebWidFactory').createWid(chatId);
-            const chat = (window.require('WAWebCollections')).Chat.get(chatWid) ?? (await (window.require('WAWebCollections')).Chat.find(chatWid));
+            const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
             if (chat?.endOfHistoryTransferType === 0) {
                 await (window.require('WAWebSendNonMessageDataRequest')).sendPeerDataOperationRequest(3, {
                     chatId: chat.id

--- a/src/structures/GroupChat.js
+++ b/src/structures/GroupChat.js
@@ -82,7 +82,9 @@ class GroupChat extends Chat {
 
             !Array.isArray(participantIds) && (participantIds = [participantIds]);
             const groupWid = window.require('WAWebWidFactory').createWid(groupId);
-            const group = (window.require('WAWebCollections')).Chat.get(groupWid) || (await (window.require('WAWebCollections')).Chat.find(groupWid));
+            // 新版页面 Chat 集合的 findImpl 已被移除,裸调 Chat.find 会抛 TypeError,
+            // 统一改用带降级链的 WWebJS.getChat(get → 内存扫描 → findOrCreateLatestChat)
+            const group = await window.WWebJS.getChat(groupId, { getAsModel: false });
             const participantWids = participantIds.map((p) => window.require('WAWebWidFactory').createWid(p));
 
             const errorCodes = {
@@ -160,7 +162,7 @@ class GroupChat extends Chat {
                     (window.require('WAWebCollections')).Contact.gadd(pWid, { silent: true });
 
                     if (rpcResult.name === 'ParticipantRequestCodeCanBeSent' &&
-                        (userChat = (window.require('WAWebCollections')).Chat.get(pWid) || (await (window.require('WAWebCollections')).Chat.find(pWid)))) {
+                        (userChat = await window.WWebJS.getChat(pWid._serialized, { getAsModel: false }))) {
                         const groupName = group.formattedTitle || group.name;
                         const res = await (window.require('WAWebChatSendMessages')).sendGroupInviteMessage(
                             userChat,

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -524,7 +524,7 @@ class Message extends Base {
     async delete(everyone, clearMedia = true) {
         await this.client.pupPage.evaluate(async (msgId, everyone, clearMedia) => {
             const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
-            const chat = (window.require('WAWebCollections')).Chat.get(msg.id.remote) || (await (window.require('WAWebCollections')).Chat.find(msg.id.remote));
+            const chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
             
             const canRevoke =
                 window.require('WAWebMsgActionCapability').canSenderRevokeMsg(msg) || window.require('WAWebMsgActionCapability').canAdminRevokeMsg(msg);
@@ -550,7 +550,7 @@ class Message extends Base {
         await this.client.pupPage.evaluate(async (msgId) => {
             const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
             if (window.require('WAWebMsgActionCapability').canStarMsg(msg)) {
-                let chat = await (window.require('WAWebCollections')).Chat.find(msg.id.remote);
+                let chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
                 return (window.require('WAWebCmd').Cmd).sendStarMsgs(chat, [msg], false);
             }
         }, this.id._serialized);
@@ -563,7 +563,7 @@ class Message extends Base {
         await this.client.pupPage.evaluate(async (msgId) => {
             const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
             if (window.require('WAWebMsgActionCapability').canStarMsg(msg)) {
-                let chat = await (window.require('WAWebCollections')).Chat.find(msg.id.remote);
+                let chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
                 return (window.require('WAWebCmd').Cmd).sendUnstarMsgs(chat, [msg], false);
             }
         }, this.id._serialized);

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -752,7 +752,19 @@ exports.LoadUtils = () => {
                 chat = null;
             }
         } else {
-            chat = (window.require('WAWebCollections')).Chat.get(chatWid);
+            // 新版页面 Chat.get 对部分 wid 会抛 memoize 校验异常,降级为 miss
+            try {
+                chat = (window.require('WAWebCollections')).Chat.get(chatWid);
+            } catch (err) {
+                chat = null;
+            }
+            // 键控查询 miss 时按 _serialized 扫描内存集合兜底
+            // (新版页面按 lid 域存储的会话,用 PN wid 推导的 key 查不到)
+            if (!chat) {
+                try {
+                    chat = (window.require('WAWebCollections')).Chat.getModelsArray().find(c => c?.id?._serialized === chatId);
+                } catch (err) { /* fall through to findOrCreateLatestChat */ }
+            }
             if (!chat) {
                 try {
                     chat = (await (window.require('WAWebFindChatAction')).findOrCreateLatestChat(chatWid))?.chat;
@@ -833,21 +845,31 @@ exports.LoadUtils = () => {
             model.isGroup = true;
             const chatWid = window.require('WAWebWidFactory').createWid(chat.id._serialized);
             const groupMetadata = (window.require('WAWebCollections')).GroupMetadata || (window.require('WAWebCollections')).WAWebGroupMetadataCollection;
-            await groupMetadata.update(chatWid);
-            chat.groupMetadata.participants._models
-                .filter(x => x.id?._serialized?.endsWith('@lid'))
-                .forEach(x => x.contact?.phoneNumber && (x.id = x.contact.phoneNumber));
+            try {
+                await groupMetadata.update(chatWid);
+            } catch (err) { /* 元数据刷新失败时使用缓存数据 */ }
+            // 对齐上游:serialize 后再转换,不原地修改页面活模型;
+            // lid 成员回填 PN 作为 id,原 lid 保存在 lid 字段
             model.groupMetadata = chat.groupMetadata.serialize();
-            model.groupMetadata.participants = chat.groupMetadata.participants._models.map(item => {
-                const result = item.serialize();
-                result.lid = result.id;
-                result.id = item.contact?.phoneNumber || result.lid;
-                return result;
+            model.groupMetadata.participants = (model.groupMetadata.participants || []).map(item => {
+                try {
+                    const rawId = item?.id?._serialized ?? item?.id;
+                    if (typeof rawId === 'string' && rawId.endsWith('@lid')) {
+                        item.lid = rawId;
+                        const pn = window.require('WAWebApiContact').getPhoneNumber(window.require('WAWebWidFactory').createWid(rawId));
+                        if (pn) item.id = pn._serialized || pn;
+                    }
+                } catch (err) { /* 保留原始 id */ }
+                return item;
             });
             if (chat.groupMetadata.owner) {
-                model.groupMetadata.lidOwner = chat.groupMetadata.owner;
-                const owner = await window.WWebJS.getContact(chat.groupMetadata.owner._serialized);
-                model.groupMetadata.owner = owner.id;
+                try {
+                    model.groupMetadata.lidOwner = chat.groupMetadata.owner;
+                    const owner = await window.WWebJS.getContact(chat.groupMetadata.owner._serialized);
+                    if (owner && owner.id) {
+                        model.groupMetadata.owner = owner.id;
+                    }
+                } catch (err) { /* 保留 serialize 产出的原始 owner */ }
             }
             model.isReadOnly = chat.groupMetadata.announce;
         }
@@ -861,10 +883,15 @@ exports.LoadUtils = () => {
 
         model.lastMessage = null;
         if (model.msgs && model.msgs.length) {
-            const lastMessage = chat.lastReceivedKey
-                ? (window.require('WAWebCollections')).Msg.get(chat.lastReceivedKey._serialized) || (await (window.require('WAWebCollections')).Msg.getMessagesById([chat.lastReceivedKey._serialized]))?.messages?.[0]
-                : null;
-            lastMessage && (model.lastMessage = window.WWebJS.getMessageModel(lastMessage));
+            // Msg.getMessagesById 走 IndexedDB,LID 群的 lastReceivedKey 推导不出
+            // DB key 会抛 DataError 并穿透整个 getChat;lastMessage 是附加信息,
+            // 失败时置 null 即可,不能让它中断会话序列化
+            try {
+                const lastMessage = chat.lastReceivedKey
+                    ? (window.require('WAWebCollections')).Msg.get(chat.lastReceivedKey._serialized) || (await (window.require('WAWebCollections')).Msg.getMessagesById([chat.lastReceivedKey._serialized]))?.messages?.[0]
+                    : null;
+                lastMessage && (model.lastMessage = window.WWebJS.getMessageModel(lastMessage));
+            } catch (err) { /* lastMessage 置 null */ }
         }
 
         delete model.msgs;
@@ -917,7 +944,15 @@ exports.LoadUtils = () => {
 
     window.WWebJS.getContacts = () => {
         const contacts = (window.require('WAWebCollections')).Contact.getModelsArray();
-        return contacts.map(contact => window.WWebJS.getContactModel(contact));
+        // 单个联系人序列化失败(新版页面 getter 对脏数据抛 memoize 校验异常)
+        // 只跳过该联系人,不能让整个联系人列表同步失败
+        return contacts.map(contact => {
+            try {
+                return window.WWebJS.getContactModel(contact);
+            } catch (err) {
+                return null;
+            }
+        }).filter(Boolean);
     };
 
     window.WWebJS.mediaInfoToFile = ({ data, mimetype, filename }) => {
@@ -1253,7 +1288,7 @@ exports.LoadUtils = () => {
 
     window.WWebJS.membershipRequestAction = async (groupId, action, requesterIds, sleep) => {
         const groupWid = window.require('WAWebWidFactory').createWid(groupId);
-        const group = await (window.require('WAWebCollections')).Chat.find(groupWid);
+        const group = await window.WWebJS.getChat(groupId, { getAsModel: false });
         const toApprove = action === 'Approve';
         let membershipRequests;
         let response;

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -49,7 +49,7 @@ class InterfaceController {
     async openChatWindowAt(msgId) {
         await this.pupPage.evaluate(async (msgId) => {
             const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
-            const chat = (window.require('WAWebCollections')).Chat.get(msg.id.remote) ?? await (window.require('WAWebCollections')).Chat.find(msg.id.remote);
+            const chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
             const searchContext = await (window.require('WAWebChatMessageSearch')).getSearchContext(chat, msg.id);
             await (window.require('WAWebCmd').Cmd).openChatAt({ chat: chat, msgContext: searchContext });
         }, msgId);


### PR DESCRIPTION
## 背景

新版 WhatsApp Web 页面(LID 寻址灰度)引入多处破坏性变更,测试环境表现为:存量群同步归零(roomCount: 0)、建群报错、群不落库、群成员列表混入脏数据。全部修复已在测试环境经 13 轮容器热改验证,最终状态:roomCount 51 全量恢复、建群/加成员/群消息端到端正常、ERR 日志归零。

## 修复内容

### 根因修
- **getChatModel lastMessage IDB 防御**:`Msg.getMessagesById` 走 IndexedDB,LID 群的 `lastReceivedKey` 推导不出 DB key,抛 `DataError: No key or key range specified` 并穿透整个 `getChat`,导致**所有群** serialize 失败(1:1 会话内存能命中所以正常)。lastMessage 是附加字段,失败置 null。

### 页面兼容
- **getChat**:`Chat.get` 对部分 wid 抛 memoize 校验异常时降级为 miss;miss 后按 `_serialized` 扫描内存集合兜底,再走 `findOrCreateLatestChat`;
- **getChatModel groupMetadata**:participants 对齐上游改为 serialize 后转换(不再原地修改页面活模型 `_models`),lid 成员回填 PN 作为 id、原 lid 存 `lid` 字段;`groupMetadata.update` / owner 处理加防御;
- **createGroup**:删除 `participantWids.map(item => item.lid = item)` 循环引用 hack(新版页面 memoize getter 遇循环引用抛 `id undefined`);catch 返回真实错误信息,不再吞成无信息字符串;
- **12 处裸 `Chat.find` 统一收口到 `WWebJS.getChat`**:新版页面 Chat 集合的 `findImpl` 已被移除,裸调必抛 TypeError(建群加成员链路即死于此)。涉及 Client.js×5、Message.js×3、GroupChat.js×2、InterfaceController.js×1、Utils.js×1;
- **getContacts**:单个联系人序列化失败(周期同步中 getter 对脏数据抛 memoize 异常)只跳过该联系人,不中断整个列表。

## 验证
- 测试环境 bot 全链路验证(存量群同步、建群、加非好友成员、群消息收发、页面群列表显示);
- `node --check` 全部通过;配套 puppet PR:juzibot/wechaty-puppet-whatsapp 的 fix/room-sync-type-safety。

## 发版
合并后走标准流程:`npm version patch`(→ 1.30.33)→ 推 v* tag → deploy.yml 发 npm。

🤖 Generated with [Claude Code](https://claude.com/claude-code)