### PR TITLE
fix: Msg 集合查找收口 getMsgById,修复 LID 会话媒体下载失败(原图打不开)

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -820,11 +820,7 @@ class Client extends EventEmitter {
                     const sender = vote.author ?? vote.from;
                     const senderUserJid = sender._serialized;
 
-                    let parentMessage = Msg.get(parentMsgKey._serialized);
-                    if (!parentMessage) {
-                        const fetched = await Msg.getMessagesById([parentMsgKey._serialized]);
-                        parentMessage = fetched?.messages?.[0] || null;
-                    }
+                    let parentMessage = await window.WWebJS.getMsgById(parentMsgKey._serialized);
 
                     return {
                         ...vote,
@@ -1400,15 +1396,10 @@ class Client extends EventEmitter {
      */
     async getMessageById(messageId) {
         const msg = await this.pupPage.evaluate(async messageId => {
-            let msg = (window.require('WAWebCollections')).Msg.get(messageId);
-            if(msg) return window.WWebJS.getMessageModel(msg);
-
             const params = messageId.split('_');
             if (params.length !== 3 && params.length !== 4) throw new Error('Invalid serialized message id specified');
 
-            let messagesObject = await (window.require('WAWebCollections')).Msg.getMessagesById([messageId]);
-            if (messagesObject && messagesObject.messages.length) msg = messagesObject.messages[0];
-            
+            const msg = await window.WWebJS.getMsgById(messageId);
             if(msg) return window.WWebJS.getMessageModel(msg);
         }, messageId);
 
@@ -1432,8 +1423,7 @@ class Client extends EventEmitter {
             const pinnedMsgs = (
                 await Promise.all(
                     msgs.filter(msg => msg.pinType == 1).map(async (msg) => {
-                        const res = await (window.require('WAWebCollections')).Msg.getMessagesById([msg.parentMsgKey]);
-                        return res?.messages?.[0];
+                        return await window.WWebJS.getMsgById(msg.parentMsgKey?._serialized || msg.parentMsgKey);
                     })
                 )
             ).filter(Boolean);
@@ -2224,7 +2214,7 @@ class Client extends EventEmitter {
             if (!status) return;
 
             const msg =
-                (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+                await window.WWebJS.getMsgById(msgId);
             if (!msg) return;
 
             if (!msg.id.fromMe || !msg.id.remote.isStatus())
@@ -2575,7 +2565,7 @@ class Client extends EventEmitter {
         if (![0, 1, 2, 3].includes(response)) return false;
 
         return await this.pupPage.evaluate(async (response, msgId) => {
-            const eventMsg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const eventMsg = await window.WWebJS.getMsgById(msgId);
             if (!eventMsg) return false;
 
             await (window.require('WAWebSendEventResponseMsgAction')).sendEventResponseMsg(response, eventMsg);

--- a/src/Client.js
+++ b/src/Client.js
@@ -1356,6 +1356,21 @@ class Client extends EventEmitter {
         await fixIdField(msg.reactionParentKey, 'participant');
         await fixIdField(msg.parentMsgKey, 'participant');
         await fixIdField(msg.msgKey, 'participant');
+
+        // LID 消息的 MsgKey 序列化产物缺 _serialized(只带 lid 形态的 $1),
+        // 而缓存 payload 及媒体下载/撤回/标星等都依赖 id._serialized;
+        // 按修复后的 PN 形态字段统一重建,保持与 remote 改写一致
+        const rebuildKeySerialized = (key) => {
+            if (!key || key.id === undefined || key.fromMe === undefined) return;
+            const remote = idOf(key.remote);
+            if (!remote) return;
+            const participant = key.participant ? idOf(key.participant) : null;
+            key._serialized = `${key.fromMe}_${remote}_${key.id}${participant ? '_' + participant : ''}`;
+        };
+        rebuildKeySerialized(msg.id);
+        rebuildKeySerialized(msg.reactionParentKey);
+        rebuildKeySerialized(msg.parentMsgKey);
+        rebuildKeySerialized(msg.msgKey);
         await fixIdField(msg, 'from');
         await fixIdField(msg, 'to');
         await fixIdField(msg, 'author');

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -326,7 +326,7 @@ class Message extends Base {
      */
     async reload() {
         const newData = await this.client.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             if (!msg) return null;
             return window.WWebJS.getMessageModel(msg);
         }, this.id._serialized);
@@ -385,7 +385,7 @@ class Message extends Base {
         if (!this.hasQuotedMsg) return undefined;
 
         const quotedMsg = await this.client.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             const quotedMsg = window.require('WAWebQuotedMsgModelUtils').getQuotedMsgObj(msg);
             return window.WWebJS.getMessageModel(quotedMsg);
         }, this.id._serialized);
@@ -425,7 +425,7 @@ class Message extends Base {
         await this.client.pupPage.evaluate(async (messageId, reaction) => {
             if (!messageId) return null;
             const msg =
-                (window.require('WAWebCollections')).Msg.get(messageId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([messageId]))?.messages?.[0];
+                await window.WWebJS.getMsgById(messageId);
             if(!msg) return null;
             await (window.require('WAWebSendReactionMsgAction'))(msg, reaction);
         }, this.id._serialized, reaction);
@@ -463,7 +463,7 @@ class Message extends Base {
         }
 
         const result = await this.client.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
 
             // REUPLOADING mediaStage means the media is expired and the download button is spinning, cannot be downloaded now
             if (!msg || !msg.mediaData || msg.mediaData.mediaStage === 'REUPLOADING') {
@@ -523,7 +523,7 @@ class Message extends Base {
      */
     async delete(everyone, clearMedia = true) {
         await this.client.pupPage.evaluate(async (msgId, everyone, clearMedia) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             const chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
             
             const canRevoke =
@@ -548,7 +548,7 @@ class Message extends Base {
      */
     async star() {
         await this.client.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             if (window.require('WAWebMsgActionCapability').canStarMsg(msg)) {
                 let chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
                 return (window.require('WAWebCmd').Cmd).sendStarMsgs(chat, [msg], false);
@@ -561,7 +561,7 @@ class Message extends Base {
      */
     async unstar() {
         await this.client.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             if (window.require('WAWebMsgActionCapability').canStarMsg(msg)) {
                 let chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
                 return (window.require('WAWebCmd').Cmd).sendUnstarMsgs(chat, [msg], false);
@@ -608,7 +608,7 @@ class Message extends Base {
      */
     async getInfo() {
         const info = await this.client.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             if (!msg || !msg.id.fromMe) return null;
 
             return new Promise((resolve) => {
@@ -642,7 +642,7 @@ class Message extends Base {
     async getPayment() {
         if (this.type === MessageTypes.PAYMENT) {
             const msg = await this.client.pupPage.evaluate(async (msgId) => {
-                const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+                const msg = await window.WWebJS.getMsgById(msgId);
                 if(!msg) return null;
                 return msg.serialize();
             }, this.id._serialized);
@@ -717,7 +717,7 @@ class Message extends Base {
             return null;
         }
         const messageEdit = await this.client.pupPage.evaluate(async (msgId, message, options) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             if (!msg) return null;
 
             let canEdit = window.require('WAWebMsgActionCapability').canEditText(msg) || window.require('WAWebMsgActionCapability').canEditCaption(msg);
@@ -745,7 +745,7 @@ class Message extends Base {
         }
 
         const edittedEventMsg = await this.client.pupPage.evaluate(async (msgId, editedEventObject) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             if (!msg) return null;
 
             const { name, startTimeTs, eventSendOptions } = editedEventObject;
@@ -787,7 +787,7 @@ class Message extends Base {
             if (!Array.isArray(votes)) votes = [votes];
             let localIdSet = new Set();
             const msg =
-                (window.require('WAWebCollections')).Msg.get(messageId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([messageId]))?.messages?.[0];
+                await window.WWebJS.getMsgById(messageId);
             if (!msg) return null;
 
             msg.pollOptions.forEach(a => {

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -114,7 +114,7 @@ exports.LoadUtils = () => {
 
     
     window.WWebJS.forwardMessage = async (chatId, msgId) => {
-        const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+        const msg = await window.WWebJS.getMsgById(msgId);
         const chat = await window.WWebJS.getChat(chatId, { getAsModel: false });
         return await (window.require('WAWebChatForwardMessage')).forwardMessages({'chat': chat, 'msgs' : [msg], 'multicast': true, 'includeCaption': true, 'appendedText' : undefined});
     };
@@ -162,8 +162,7 @@ exports.LoadUtils = () => {
 
         let quotedMsgOptions = {};
         if (options.quotedMessageId) {
-            let quotedMessage = (window.require('WAWebCollections')).Msg.get(options.quotedMessageId);
-            !quotedMessage && (quotedMessage = (await (window.require('WAWebCollections')).Msg.getMessagesById([options.quotedMessageId]))?.messages?.[0]);
+            let quotedMessage = await window.WWebJS.getMsgById(options.quotedMessageId);
             if (quotedMessage) {
 
                 const ReplyUtils = window.require('WAWebMsgReply');
@@ -737,6 +736,39 @@ exports.LoadUtils = () => {
         return msg;
     };
 
+    window.WWebJS.getMsgById = async (msgId) => {
+        const Msg = (window.require('WAWebCollections')).Msg;
+        let msg = null;
+        // 新版页面对部分 key 的 get 会抛 memoize 校验异常,降级为 miss
+        try {
+            msg = Msg.get(msgId);
+        } catch (err) {
+            msg = null;
+        }
+        // LID 会话的消息在页面集合按 lid 形态 key 存储,PN 形态的 key 查不到;
+        // 按 fromMe + 内层消息 id 扫描内存集合兜底
+        if (!msg) {
+            try {
+                const parts = String(msgId).split('_');
+                const innerId = parts[2];
+                if (innerId) {
+                    const fromMe = parts[0] === 'true';
+                    msg = Msg.getModelsArray().find(m => m?.id?.id === innerId && m?.id?.fromMe === fromMe);
+                }
+            } catch (err) { /* fall through */ }
+        }
+        // getMessagesById 走 IndexedDB,LID 形态 key 推导失败会抛 DataError,
+        // 不能让它把调用方(下载原图/撤回/标星等)整个打挂
+        if (!msg) {
+            try {
+                msg = (await Msg.getMessagesById([msgId]))?.messages?.[0];
+            } catch (err) {
+                msg = null;
+            }
+        }
+        return msg || null;
+    };
+
     window.WWebJS.getChat = async (chatId, { getAsModel = true } = {}) => {
         const isChannel = /@\w*newsletter\b/.test(chatId);
         const chatWid = window.require('WAWebWidFactory').createWid(chatId);
@@ -883,12 +915,11 @@ exports.LoadUtils = () => {
 
         model.lastMessage = null;
         if (model.msgs && model.msgs.length) {
-            // Msg.getMessagesById 走 IndexedDB,LID 群的 lastReceivedKey 推导不出
-            // DB key 会抛 DataError 并穿透整个 getChat;lastMessage 是附加信息,
-            // 失败时置 null 即可,不能让它中断会话序列化
+            // lastMessage 是附加信息,查找失败时置 null 即可,不能让它中断
+            // 会话序列化(getMsgById 内部已含 LID 兜底与 IDB 防御)
             try {
                 const lastMessage = chat.lastReceivedKey
-                    ? (window.require('WAWebCollections')).Msg.get(chat.lastReceivedKey._serialized) || (await (window.require('WAWebCollections')).Msg.getMessagesById([chat.lastReceivedKey._serialized]))?.messages?.[0]
+                    ? await window.WWebJS.getMsgById(chat.lastReceivedKey._serialized)
                     : null;
                 lastMessage && (model.lastMessage = window.WWebJS.getMessageModel(lastMessage));
             } catch (err) { /* lastMessage 置 null */ }
@@ -1401,7 +1432,7 @@ exports.LoadUtils = () => {
     };
 
     window.WWebJS.pinUnpinMsgAction = async (msgId, action, duration) => {
-        const message = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+        const message = await window.WWebJS.getMsgById(msgId);
         if (!message) return false;
 
         if (typeof duration !== 'number') return false;

--- a/src/util/InterfaceController.js
+++ b/src/util/InterfaceController.js
@@ -48,7 +48,7 @@ class InterfaceController {
      */
     async openChatWindowAt(msgId) {
         await this.pupPage.evaluate(async (msgId) => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             const chat = await window.WWebJS.getChat(msg.id.remote._serialized || msg.id.remote, { getAsModel: false });
             const searchContext = await (window.require('WAWebChatMessageSearch')).getSearchContext(chat, msg.id);
             await (window.require('WAWebCmd').Cmd).openChatAt({ chat: chat, msgContext: searchContext });
@@ -61,7 +61,7 @@ class InterfaceController {
      */
     async openMessageDrawer(msgId) {
         await this.pupPage.evaluate(async msgId => {
-            const msg = (window.require('WAWebCollections')).Msg.get(msgId) || (await (window.require('WAWebCollections')).Msg.getMessagesById([msgId]))?.messages?.[0];
+            const msg = await window.WWebJS.getMsgById(msgId);
             await (window.require('WAWebCmd').Cmd).msgInfoDrawer(msg);
         }, msgId);
     }


### PR DESCRIPTION
## 背景(工单 #7053334985,Z 区,严重工单)

LID 灰度会话(客户联系人为 lid 寻址)的消息,页面 Msg 集合按 **lid 形态** key 存储(如 `false_xxx@lid_3A10...`),而 Node 侧持有 PN 形态 id(`false_xxx@c.us_3A10...`,fork lid 屏蔽策略产物)。所有裸 `Msg.get(id) || Msg.getMessagesById([id])` 调用:get 必 miss → getMessagesById 走 IndexedDB → key 推导失败抛混淆异常 `r`。

**线上实证**(z-region):客户点"查看原图" → `ERR OtherService loadArtworkImage() error ... detailed error: r: r at #evaluate` → fallback 把 71×72 缩略图当原图返回。消息体里 `directPath`/`mediaKey`/`encFilehash` 凭证齐全,下载本可成功——死在"找消息"第一步。**升级到 1.30.33 后仍复现**(1.30.33 收口的是 Chat 集合,Msg 集合未覆盖)。

## 修复

新增 `window.WWebJS.getMsgById(msgId)` 三级查找:
1. `Msg.get`(try/catch 防 memoize 校验异常);
2. miss 后按 `fromMe` + 内层消息 id(`3A10...` 段)扫描内存集合——**LID 形态差异的兜底**;
3. 仍 miss 才走 `getMessagesById`(try/catch 防 IDB DataError)。

全部 **21 处**裸 Msg 查找收口到该 helper:Message.js×12(downloadMedia/delete/star/unstar/pin/react/edit 等)、Client.js×4(getMessageById/pollVote/pinnedMessages)、InterfaceController.js×2、Utils.js×3(forwardMessage、sendMessage quotedMessage、getChatModel lastMessage——lastMessage 由 1.30.33 的"失败置 null"升级为可通过内存扫描找回)。

与 #33 的 `Chat.find` 收口同模式,是 LID 家族在 Msg 集合的对应修复。

## 验证
- `node --check` 4 个文件全过;
- 待合并后发 1.30.34,Z 区升级后用工单场景复验(LID 联系人图片 → 点查看原图 → 应得到真原图而非 71×72 缩略图,`loadArtworkImage() error` 归零)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)