### PR TITLE
fix: getContact 不再用空 phoneNumber 覆写 contact.id

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1325,6 +1325,9 @@ class Client extends EventEmitter {
 
             return contact?.id._serialized;
         } catch (err) {
+            // 这里原先静默返回 null,导致 LID 联系人序列化失败没有任何痕迹,
+            // 后续报错会出现在完全不相干的调用上,无法回溯来源
+            console.warn(`getOriginalContactIdByLid(${lid}) failed: ${err.message}`);
             return null;
         }
         

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -965,7 +965,10 @@ exports.LoadUtils = () => {
     window.WWebJS.getContact = async contactId => {
         const wid = window.require('WAWebWidFactory').createWid(contactId);
         let contact = await (window.require('WAWebCollections')).Contact.find(wid);
-        if (contact.id._serialized.endsWith('@lid')) {
+        // Contact.find() 返回的是 Store 中全页面共享的活对象。phoneNumber 尚未映射出来时
+        // 若仍然覆写,会把 contact.id 写成 undefined 并持久污染该对象,
+        // 导致此后任意代码(含页面自身机制)碰到它都触发 getter 的 memoize 校验异常
+        if (contact.id && contact.id._serialized.endsWith('@lid') && contact.phoneNumber) {
             contact.id = contact.phoneNumber;
         }
         const bizProfile = await (window.require('WAWebCollections')).BusinessProfile.fetchBizProfile(wid);


### PR DESCRIPTION
## 变更

| 文件 | 改动 |
|------|------|
| `src/util/Injected/Utils.js:968` | `getContact` 覆写 `contact.id` 前增加 `contact.phoneNumber` 非空判断（并补 `contact.id` 存在性判断） |
| `src/Client.js:1327` | `getOriginalContactIdByLid` 的 `catch` 补一行 `console.warn` |

## 根因

`Contact.find()` 返回的是 Store 中**全页面共享的活对象**。此前对 `@lid` 联系人无条件执行：

```js
contact.id = contact.phoneNumber;
```

WhatsApp LID 寻址灰度下，存在只有 `@lid`、`phoneNumber` 尚未映射出来的联系人。此时这行等于 `contact.id = undefined`，**持久污染**该共享对象。之后任意代码（包括 WhatsApp 页面自身机制）碰到它，都会触发 getter 的 memoize 校验异常：

```
Error: Data passed to getter must include an id property (it's how we memoize) but got undefined
  at Object.h [as getIsMe] (https://static.whatsapp.net/rsrc.php/v4/ym/r/8Q2C_SI3nB5.js:243:2443)
```

因为污染的是共享活对象，报错会落在与污染动作**完全不相干**的调用上。线上实测两次报错分别出现在发消息（`MessageSender`）和加好友（`ContactService friendship`）链路，相隔 44 分钟，无法从报错点回溯来源。

调用链：

```
消息事件 → fixMessageLid (Client.js 9 处调用)
  → getOriginalContactIdByLid('<xxx>@lid')
    → getContactById → 页面 WWebJS.getContact
      → Utils.js:968  id 以 @lid 结尾，判断为真
      → Utils.js:969  contact.id = undefined     ← 污染 Store 活对象
      → Utils.js:973  getContactModel → getIsMe 抛错
    → Client.js:1328  catch 静默 return null     ← 唯一痕迹被吞掉
── 数十分钟后 ──
发消息 / 加好友 → 页面机制碰到坏对象 → 再次抛 getIsMe
```

## 为什么修这里，而不是继续在下游兜

`getContacts` 已经兜过两次同一个症状：

- 1.30.17 用 `.filter(item => !!item.id)`
- 1.30.34 改为 `try/catch`，注释写的是「新版页面 getter 对脏数据抛 memoize 校验异常」

两次都在下游跳过坏数据，没有修污染源。全仓库能写出 `id === undefined` 的地方只有 `Utils.js:969` 这一处，掐掉它，所有下游症状一并消失。

## 风险

低。`phoneNumber` 有值时行为与今天完全一致，只在 `phoneNumber` 缺失时跳过覆写。

跳过后返回的 `id` 保持为原始 `@lid`，与「覆写成 `undefined`」相比是严格改善。上游 `getOriginalContactIdByLid` 已有 `contact?.id._serialized` 可选链，`fixMessageLid` 也对结果做 `if (contactId)` 判空，能正常处理。

**刻意没做**的一件事：不把 `id` 覆写挪到 `getContactModel()` 之后（即「改副本不改活对象」）。那样会让 `getIsMe`/`getIsUser` 等 getter 收到 `@lid` 身份而非 `@c.us` 身份，`res.isUser` 等字段可能翻转，在没有 LID 灰度账号的情况下无法验证。留待单独 PR。

`console.warn` 走的是 `Client.js` 既有惯例（同文件另有 5 处）。

## 测试

- ✅ `node --check` 两个文件语法通过
- ❌ **`npm run lint` 未执行** — 仓库依赖未安装，`npx` 需拉取 `eslint@10.8.0` 失败。改动为 1 个判断条件 + 4 行注释，缩进 4 空格与模板字符串风格与周边一致，CI lint workflow 可兜
- ⚠️ **未在 LID 灰度账号实机复现** — 手头无该环境

复现方式（供有环境者验证）：找一个 Store 里为 `@lid`、`phoneNumber` 未映射的联系人，调 `getContactById('<lid>@lid')`。

- 修复前：`contact.id` 变 `undefined`，抛 `getIsMe` 错，且此后任何碰到该联系人的操作都会报错
- 修复后：正常返回，Store 里 `contact.id._serialized` 仍是原 `@lid`（未被污染）

## 回滚

`git revert 82e6266`。纯增加防御判断，无数据迁移、无接口变更，回滚即恢复原行为。

## 合并后

本次未动 `package.json`（与 `fix/lid-*` 四个分支的既有惯例一致，版本号由维护者单独提交）。需要发 `1.30.35` 后，`xiaoju-bot` 侧才能通过 `@juzi/wechaty-puppet-whatsapp` 的 `^1.30.34` 取到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
