### PR TITLE
fix: 群 @成员 兼容 LID 回填后的 wid 字符串形态

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: install npm
-        run: npm install npm@latest -g
+        run: npm install npm@11 -g
             
       - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/whatsapp-web.js",
-  "version": "1.30.34",
+  "version": "1.30.35",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/Client.js
+++ b/src/Client.js
@@ -1026,23 +1026,29 @@ class Client extends EventEmitter {
     
         if (options.mentions) {
             const group = await this.getChatById(chatId);
+            // LID 灰度回填后 participant.id/lid 可能是字符串(getChatModel 中
+            // 回填 pn._serialized),老形态则是 {_serialized} 对象,两种都要认
+            const widToString = (wid) => typeof wid === 'string' ? wid : wid?._serialized;
             const participants = options.mentions.map(mention => {
-                const result = group.participants.find(participant => participant.id._serialized === mention);
+                const result = group.participants.find(participant =>
+                    widToString(participant.id) === mention || widToString(participant.lid) === mention
+                );
                 if (!result) {
                     throw new Error(`participant ${mention} is not in the group`);
                 }
                 return result;
             });
-            options.mentions = participants.map(participant => participant.lid._serialized);
+            options.mentions = participants.map(participant => widToString(participant.lid) || widToString(participant.id));
             !Array.isArray(options.mentions) && (options.mentions = [options.mentions]);
             if (options.mentions.some((possiblyContact) => possiblyContact instanceof Contact)) {
                 console.warn('Mentions with an array of Contact are now deprecated. See more at https://github.com/pedroslopez/whatsapp-web.js/pull/2166.');
                 options.mentions = options.mentions.map((a) => a.id._serialized);
             }
             for (const mentionedParticipant of participants) {
-                const contact = await this.getContactById(mentionedParticipant.id._serialized);
+                const contact = await this.getContactById(widToString(mentionedParticipant.id));
                 if (contact) {
-                    content = content.replaceAll(`@${contact.name}`, `@${mentionedParticipant.lid.user}`).replaceAll(`@${contact.pushname}`, `@${mentionedParticipant.lid.user}`);
+                    const mentionTag = (widToString(mentionedParticipant.lid) || widToString(mentionedParticipant.id)).split('@')[0];
+                    content = content.replaceAll(`@${contact.name}`, `@${mentionTag}`).replaceAll(`@${contact.pushname}`, `@${mentionTag}`);
                 }
             }
         }


### PR DESCRIPTION
## 问题

LID 灰度群里 @成员 发消息，稳定报：

```
participant 84965021695@c.us is not in the group
```

成员实际就在群里，`@c.us` 形态也是对的。

## 根因

`getChatModel`（`src/util/Injected/Utils.js`）对 LID 群成员回填 PN 时：

```js
if (typeof rawId === 'string' && rawId.endsWith('@lid')) {
    item.lid = rawId;
    const pn = getPhoneNumber(createWid(rawId));
    if (pn) item.id = pn._serialized || pn;   // ← id 变成【字符串】
}
```

而 `sendMessage` 的 mentions 匹配仍按对象读：

```js
group.participants.find(participant => participant.id._serialized === mention)
```

对字符串取 `._serialized` 得 `undefined`，与任何 mention 都不相等 → 必抛。

只有 LID 群走这个回填分支，非 LID 群 `item.id` 仍是 `{_serialized}` 对象、匹配正常——所以现象是「只有部分群/部分账号报」。

## 改动

- 匹配经 `widToString` 归一，同时比对 `participant.id` 与 `participant.lid`，字符串 / `{_serialized}` 两种形态都认
- `options.mentions` 取值与 `@名字` 替换的 tag 一并归一：原先的 `participant.lid._serialized` / `lid.user` 在字符串态下同样会崩，只修 `find` 会在下一行换个姿势挂掉
- `lid` 缺失时回落到 `id`

另附一个 CI commit：`npm@latest` 已到 12.0.2，npm 12 覆盖 runner 自带 npm 后 `npm publish` 会因 `Cannot find module 'sigstore'` 崩溃，打 tag 发不出包。钉 `npm@11`，与 `wechaty-puppet-whatsapp` b96255a 同一改法。

## 验证

- `eslint src/Client.js` 通过
- 补丁产物做过语法自检
- 容器热改验证路径：直接改 `node_modules/@juzi/whatsapp-web.js/src/Client.js` 重启进程

## 未覆盖

`getPhoneNumber` 拿不到手机号时，`id` 与 `lid` 都是 `@lid` 形态，此时上游传 `@c.us` 仍匹配不上。那条要在注入层补 PN 兜底，不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTBWheJ2nqCU7aWQNYQcFk
