### PR TITLE
fix: LID 成员取不到手机号时反解 lid 兜底匹配 mentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/whatsapp-web.js",
-  "version": "1.30.35",
+  "version": "1.30.36",
   "description": "Library for interacting with the WhatsApp Web API ",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/Client.js
+++ b/src/Client.js
@@ -1029,15 +1029,41 @@ class Client extends EventEmitter {
             // LID 灰度回填后 participant.id/lid 可能是字符串(getChatModel 中
             // 回填 pn._serialized),老形态则是 {_serialized} 对象,两种都要认
             const widToString = (wid) => typeof wid === 'string' ? wid : wid?._serialized;
-            const participants = options.mentions.map(mention => {
-                const result = group.participants.find(participant =>
-                    widToString(participant.id) === mention || widToString(participant.lid) === mention
-                );
-                if (!result) {
-                    throw new Error(`participant ${mention} is not in the group`);
+            const findParticipant = (...candidates) => group.participants.find(participant =>
+                candidates.some(candidate => candidate && (
+                    widToString(participant.id) === candidate || widToString(participant.lid) === candidate
+                ))
+            );
+
+            const directHits = options.mentions.map(mention => findParticipant(mention));
+
+            // getChatModel 回填 PN 依赖 getPhoneNumber,拿不到号时该成员在
+            // participants 里只留 @lid 形态,而上游传的是 @c.us,直接比对必然落空。
+            // 只对落空的这几个反解一次 lid/pn 再匹配,正常路径不付出额外往返。
+            const unresolved = directHits.reduce(
+                (acc, participant, index) => participant ? acc : [...acc, index], []
+            );
+            let recovered = new Map();
+            if (unresolved.length) {
+                let pairs = [];
+                try {
+                    pairs = await this.getContactLidAndPhone(unresolved.map(index => options.mentions[index]));
+                } catch (err) {
+                    console.warn(`Failed to resolve lid/pn for unmatched mentions: ${err.message}`);
                 }
-                return result;
+                recovered = new Map(unresolved.map((index, i) => {
+                    const { lid, pn } = pairs[i] || {};
+                    return [index, findParticipant(lid, pn)];
+                }));
+            }
+
+            const participants = directHits.map((participant, index) => participant || recovered.get(index));
+            participants.forEach((participant, index) => {
+                if (!participant) {
+                    throw new Error(`participant ${options.mentions[index]} is not in the group`);
+                }
             });
+
             options.mentions = participants.map(participant => widToString(participant.lid) || widToString(participant.id));
             !Array.isArray(options.mentions) && (options.mentions = [options.mentions]);
             if (options.mentions.some((possiblyContact) => possiblyContact instanceof Contact)) {


### PR DESCRIPTION
## 背景

#36 修的是 LID 回填**成功**时的形态不匹配（`participant.id` 变字符串，匹配却按对象取 `._serialized`）。当时留了一条没覆盖的路径，这个 PR 补上。

## 剩下的那条路径

`getChatModel` 回填 PN 靠 `getPhoneNumber`：

```js
if (typeof rawId === 'string' && rawId.endsWith('@lid')) {
    item.lid = rawId;
    const pn = getPhoneNumber(createWid(rawId));
    if (pn) item.id = pn._serialized || pn;   // ← 拿不到号就不回填
}
```

拿不到号时该成员在 `participants` 里 `id` 和 `lid` 都只有 `@lid` 形态，而上游传的 `mentionIdList` 是 `@c.us`，两边比对必然落空——同样报 `participant xxx@c.us is not in the group`。

## 改动

- 匹配抽成 `findParticipant(...candidates)`，支持多候选
- 只对**直接比对落空**的那几个 mention 调 `getContactLidAndPhone`（现成方法，内部走 `enforceLidAndPnRetrieval` → `queryWidExists` 强制拉一次），拿到 lid/pn 后再匹配一次
- 正常路径不付出额外往返；反解失败或仍找不到，抛的还是原来的错误信息

## 验证

仓里没有 mentions 相关测试（`tests/` 全是需要真实连接的集成测试），**这个改动没有真机验证过**。把匹配逻辑五种 participants 形态跑了一遍：

| 形态 | 结果 |
|---|---|
| 老形态（id/lid 都是对象） | 直接命中，反解 0 次 |
| LID 回填成功（都是字符串） | 直接命中，反解 0 次 |
| 回填失败只剩 @lid ← 本次修的 | 反解 1 次后命中 |
| 回填失败且反解也拿不到 | 抛原错误 |
| 真不在群 | 抛原错误 |

`eslint src/Client.js` 通过。

## 一处相关但未动的地方

`src/structures/GroupChat.js:198` 的 `removeParticipants` 里有 `p.lid._serialized` / `p.id._serialized`，在字符串态下是同一类缺陷（`promoteParticipants` 等几处同理）。不在本 PR 范围，需要的话另开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
